### PR TITLE
chore: add Vercel configuration files for client and server

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/index.html"
+        }
+    ]
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,15 +1,15 @@
-import express, { Request, Response } from 'express';
-import cors from 'cors';
-import 'dotenv/config';
-import { connect } from 'node:http2';
-import connectDB from './configs/db.js';
-import MongoStore from 'connect-mongo';
-import session from 'express-session';
-import AuthRouter from './routes/AuthRoutes.js';
-import ThumbnailRouter from './routes/ThumbnailRoutes.js';
-import UserRouter from './routes/UserRoutes.js';
+import express, { Request, Response } from "express";
+import cors from "cors";
+import "dotenv/config";
+import connectDB from "./configs/db.js";
+import session from "express-session";
+import MongoStore from "connect-mongo";
 
-declare module 'express-session' {
+import AuthRouter from "./routes/AuthRoutes.js";
+import ThumbnailRouter from "./routes/ThumbnailRoutes.js";
+import UserRouter from "./routes/UserRoutes.js";
+
+declare module "express-session" {
     interface SessionData {
         isLoggedIn: boolean;
         userId: string;
@@ -19,31 +19,45 @@ declare module 'express-session' {
 await connectDB();
 const app = express();
 
-app.use(cors({
-    origin:['http://localhost:5173','http://localhost:3000'],
-    credentials:true
-}))
-app.use(session({
-    secret: process.env.SESSION_SECRET as string,
-    resave: false,
-    saveUninitialized: false,
-    cookie: { maxAge: 1000 * 60 * 60 * 24 * 7 },// 7 days
-    store: MongoStore.create({
-        mongoUrl: process.env.MONGODB_URI as string,
-        collectionName: 'sessions'
+app.use(
+    cors({
+        origin: ["http://localhost:5173", "http://localhost:3000"],
+        credentials: true,
     })
-}))
+);
+
+app.use(
+    session({
+        secret: process.env.SESSION_SECRET as string,
+        resave: false,
+        saveUninitialized: false,
+        store: MongoStore.create({
+            mongoUrl: process.env.MONGODB_URI as string,
+            collectionName: "sessions",
+        }),
+        cookie: {
+            maxAge: 1000 * 60 * 60 * 24 * 7, // 7 days
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
+        },
+    })
+);
+
 app.use(express.json());
 
-
-app.get('/', (req: Request, res: Response) => {
-    res.send('Server is Live!');
+app.get("/", (_req: Request, res: Response) => {
+    res.send("Server is Live!");
 });
-app.use('/api/auth',AuthRouter)
-app.use('/api/thumbnail',ThumbnailRouter)
-app.use('/api/user',UserRouter)
+
+app.use("/api/auth", AuthRouter);
+app.use("/api/thumbnail", ThumbnailRouter);
+app.use("/api/user", UserRouter);
+
 const port = process.env.PORT || 3000;
 
 app.listen(port, () => {
     console.log(`Server is running at http://localhost:${port}`);
 });
+
+export default app;

--- a/server/vercel.json
+++ b/server/vercel.json
@@ -1,0 +1,15 @@
+{
+    "version": 2,
+    "builds": [
+        {
+            "src": "dist/server.js",
+            "use": "@vercel/node"
+        }
+    ],
+    "routes": [
+        {
+            "src": "/(.*)",
+            "dest": "/dist/server.js"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request introduces configuration changes to support Vercel deployment for both the client and server, and also refactors the server setup for improved security and maintainability. The most significant updates are grouped below.

**Vercel Deployment Configuration:**

* Added `vercel.json` to the client directory to enable SPA-style rewrites, ensuring all routes are served by `index.html`.
* Added `vercel.json` to the server directory to specify the build process and routing for the Node.js server using Vercel's serverless functions.

**Server Setup and Security Improvements:**

* Refactored `server.ts` to improve import organization and formatting, and updated CORS and session middleware configuration for clarity and maintainability.
* Enhanced session cookie security in `server.ts` by setting `httpOnly`, `secure`, and `sameSite` attributes based on environment, and moved cookie configuration inside the session middleware.
* Exported the Express `app` instance from `server.ts` for improved testability and deployment flexibility.