### PR TITLE
fix: update Vercel configuration for client and server routing

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -2,7 +2,7 @@
     "rewrites": [
         {
             "source": "/(.*)",
-            "destination": "/index.html"
+            "destination": "/"
         }
     ]
 }

--- a/server/vercel.json
+++ b/server/vercel.json
@@ -2,14 +2,19 @@
     "version": 2,
     "builds": [
         {
-            "src": "dist/server.js",
-            "use": "@vercel/node"
+            "src": "server.ts",
+            "use": "@vercel/node",
+            "config": {
+                "includeFiles": [
+                    "dist/**"
+                ]
+            }
         }
     ],
     "routes": [
         {
             "src": "/(.*)",
-            "dest": "/dist/server.js"
+            "dest": "server.ts"
         }
     ]
 }


### PR DESCRIPTION
This pull request updates the Vercel deployment configuration for both the client and server. The changes streamline routing and improve how the server build handles included files, making deployment more robust and maintainable.

**Server deployment improvements:**

- Changed the server entry point from the compiled `dist/server.js` to the TypeScript source file `server.ts` in both the build and routing configuration, and added a config to ensure the `dist` directory is included during deployment.

**Client routing update:**

- Updated the client rewrite rule to route all requests to the root path `/` instead of `/index.html`, which can help with SPA routing and compatibility.