### PR TITLE
feat: add frontend URL to CORS configuration

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -21,7 +21,7 @@ const app = express();
 
 app.use(
     cors({
-        origin: ["http://localhost:5173", "http://localhost:3000"],
+        origin: ["http://localhost:5173", "http://localhost:3000", process.env.FRONTEND_URL as string],
         credentials: true,
     })
 );


### PR DESCRIPTION
This pull request updates the allowed origins for CORS in the Express server configuration to support an additional frontend URL specified by the `FRONTEND_URL` environment variable. This makes it easier to deploy the application with different frontend URLs without changing the code.

Configuration update:

* Updated the `cors` middleware in `server/server.ts` to include `process.env.FRONTEND_URL` as an allowed origin, in addition to the existing localhost URLs.